### PR TITLE
feat: v4 v5 redirect param order

### DIFF
--- a/transforms/__test__/redirect.spec.ts
+++ b/transforms/__test__/redirect.spec.ts
@@ -1,0 +1,3 @@
+import { testSpecBuilder } from "./util";
+
+testSpecBuilder("redirect");

--- a/transforms/__test__/util.ts
+++ b/transforms/__test__/util.ts
@@ -1,0 +1,16 @@
+import { defineTest } from "jscodeshift/src/testUtils";
+
+import { readdirSync } from "node:fs";
+import { join } from "path";
+
+export function testSpecBuilder(fixtureDir: string) {
+  const fixtureDirPath = join(__dirname, "..", "__testfixtures__", fixtureDir);
+  const fixtures = readdirSync(fixtureDirPath)
+    .filter((file) => file.endsWith(".input.ts"))
+    .map((file) => file.replace(".input.ts", ""));
+
+  for (const fixture of fixtures) {
+    const prefix = `${fixtureDir}/${fixture}`;
+    defineTest(__dirname, fixtureDir, null, prefix, { parser: "ts" });
+  }
+}

--- a/transforms/__testfixtures__/redirect/redirect.input.ts
+++ b/transforms/__testfixtures__/redirect/redirect.input.ts
@@ -1,0 +1,7 @@
+import express from "express";
+
+const app = express();
+
+app.get("/", function (req, res) {
+  res.redirect("/other-page", 301);
+});

--- a/transforms/__testfixtures__/redirect/redirect.output.ts
+++ b/transforms/__testfixtures__/redirect/redirect.output.ts
@@ -1,0 +1,7 @@
+import express from "express";
+
+const app = express();
+
+app.get("/", function (req, res) {
+  res.redirect(301, "/other-page");
+});

--- a/transforms/redirect.ts
+++ b/transforms/redirect.ts
@@ -1,0 +1,22 @@
+import { API, FileInfo, withParser, CallExpression } from "jscodeshift";
+
+export default function transformer(file: FileInfo, _api: API) {
+  const parser = withParser("ts");
+
+  return parser(file.source)
+    .find(CallExpression, {
+      callee: {
+        property: {
+          name: "redirect",
+        },
+      },
+    })
+    .map((path) => {
+      if (path.value.arguments.length === 2) {
+        path.value.arguments.reverse();
+      }
+
+      return path;
+    })
+    .toSource();
+}


### PR DESCRIPTION
To address one of the points mentioned in issue:

- https://github.com/bjohansebas/codemod/issues/1

from migration guide: https://expressjs.com/en/guide/migrating-5.html

> res.json(obj, status)
> Express 5 no longer supports the signature res.json(obj, status). Instead, set the status and then chain it to the res.json() method like this: res.status(status).json(obj).