### PR TITLE
feat: add draft for missing transforms

### DIFF
--- a/transforms/json.ts
+++ b/transforms/json.ts
@@ -1,0 +1,20 @@
+import type { API, FileInfo } from 'jscodeshift'
+import { CallExpression, withParser } from 'jscodeshift'
+
+export default function transformer(file: FileInfo, _api: API): string {
+  const parser = withParser('ts')
+
+  return (
+    parser(file.source)
+      .find(CallExpression, {
+        callee: {
+          property: {
+            name: 'json',
+          },
+        },
+      })
+      // TODO: res.json(status, obj) and res.json(obj, status) signatures: Use res.status(status).json(obj).
+      // TODO: res.jsonp(status, obj) and res.jsonp(obj, status) signatures: Use res.status(status).jsonp(obj).
+      .toSource()
+  )
+}

--- a/transforms/param.ts
+++ b/transforms/param.ts
@@ -1,0 +1,20 @@
+import type { API, FileInfo } from 'jscodeshift'
+import { CallExpression, withParser } from 'jscodeshift'
+
+export default function transformer(file: FileInfo, _api: API): string {
+  const parser = withParser('ts')
+
+  return (
+    parser(file.source)
+      .find(CallExpression, {
+        callee: {
+          property: {
+            name: 'json',
+          },
+        },
+      })
+      // TODO: app.param(fn): This method has been deprecated. Instead, access parameters directly via req.params, or use req.body or req.query as needed.
+      // Add comment line before with this information
+      .toSource()
+  )
+}

--- a/transforms/send.ts
+++ b/transforms/send.ts
@@ -1,0 +1,20 @@
+import type { API, FileInfo } from 'jscodeshift'
+import { CallExpression, withParser } from 'jscodeshift'
+
+export default function transformer(file: FileInfo, _api: API): string {
+  const parser = withParser('ts')
+
+  return (
+    parser(file.source)
+      .find(CallExpression, {
+        callee: {
+          property: {
+            name: 'send',
+          },
+        },
+      })
+      // TODO: res.send(status, body) and res.send(body, status) signatures: Use res.status(status).send(body).
+      // TODO: res.send(status) signature: Use res.sendStatus(status) for simple status responses, or res.status(status).send() for sending a status code with an optional body.
+      .toSource()
+  )
+}


### PR DESCRIPTION
I have listed missing deprecated transforms to implement

> res.send(status, body) and res.send(body, status) signatures: Use res.status(status).send(body).

> res.send(status) signature: Use res.sendStatus(status) for simple status responses, or res.status(status).send() for sending a status code with an optional body.

> res.json(status, obj) and res.json(obj, status) signatures: Use res.status(status).json(obj).

> res.jsonp(status, obj) and res.jsonp(obj, status) signatures: Use res.status(status).jsonp(obj).

> app.param(fn): This method has been deprecated. Instead, access parameters directly via req.params, or use req.body or req.query as needed.